### PR TITLE
Fix kinetics movement consistency

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
@@ -18,7 +18,7 @@ import com.bitdecay.jump.level.builder.TileObject;
  */
 public class BitWorld {
 	public static final String VERSION = "0.1.2";
-	public static final float STEP_SIZE = 1 / 120f;
+	public static final float STEP_SIZE = 1 / 128f;
 	/**
 	 * Holds left-over time when there isn't enough time for a full
 	 * {@link #STEP_SIZE}

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
@@ -345,7 +345,7 @@ public class LevelEditor extends InputAdapter implements Screen, OptionsUICallba
         if (Gdx.input.isKeyJustPressed(Keys.GRAVE)) {
             stepWorld = !stepWorld;
         }
-        if (!stepWorld && Gdx.input.isKeyJustPressed(Keys.PLUS)) {
+        if (!stepWorld && (Gdx.input.isKeyJustPressed(Keys.PLUS) || Gdx.input.isKeyJustPressed(Keys.EQUALS))) {
             singleStep = true;
         }
 

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/MovingPlatformMouseMode.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/MovingPlatformMouseMode.java
@@ -22,7 +22,7 @@ public class MovingPlatformMouseMode extends BaseMouseMode {
     private float platformPause;
 
     private BitPointInt speedPoint;
-    private float platformSpeed = 30;
+    private float platformSpeed = 32;
 
     private BitRectangle platform;
     private List<PathPoint> pathPoints;


### PR DESCRIPTION
@Kenoshen this is my proposed fix for the kinetics thing.

The gist of it is:
* See how far we should move this update
* If we overshoot our goal, see what percent of our movement was overshot
* Take this remaining percent and how fast we should be traveling toward the next node and add that vector to our current move

There's a lot of math happening there, but it will only be hit when a platform hits a node on its path.

Fixes #40 
