### PR TITLE
Fix undo-redo stack

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelBuilder.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelBuilder.java
@@ -234,9 +234,11 @@ public class LevelBuilder {
 	}
 
 	public void deleteSelected() {
-		BuilderAction deleteAction = new BuilderAction(BuilderAction.Type.DELETE, selection.toArray(new LevelObject[selection.size()]));
-		pushAction(deleteAction);
-		selection.clear();
+		if (selection.size() > 0) {
+			BuilderAction deleteAction = new BuilderAction(BuilderAction.Type.DELETE, selection.toArray(new LevelObject[selection.size()]));
+			pushAction(deleteAction);
+			selection.clear();
+		}
 	}
 
 	public void selectObjects(BitRectangle selectionArea, boolean add) {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
@@ -374,11 +374,11 @@ public class LevelEditor extends InputAdapter implements Screen, OptionsUICallba
             }
         }
 
-        if (Gdx.input.isKeyPressed(Keys.ESCAPE)) {
+        if (Gdx.input.isKeyJustPressed(Keys.ESCAPE)) {
             loadLevel(curLevelBuilder.optimizeLevel());
         }
 
-        if (Gdx.input.isKeyPressed(Keys.DEL) || Gdx.input.isKeyPressed(Keys.BACKSPACE)) {
+        if (Gdx.input.isKeyJustPressed(Keys.DEL) || Gdx.input.isKeyJustPressed(Keys.BACKSPACE)) {
             curLevelBuilder.deleteSelected();
         }
 


### PR DESCRIPTION
Fixes #46 

It was caused because a user could hold down the delete keys and cause multiple delete calls to be made.