### PR TITLE
Fix one-ways. Split rendering and collision neighbor values. UI cleanup

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/collision/SATResolution.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/SATResolution.java
@@ -72,7 +72,7 @@ public class SATResolution {
                                 float resolutionPosition = body.aabb.xy.plus(axisOver.axis.times(axisOver.distance)).dot(axisOver.axis);
                                 float lastPosition = body.lastPosition.dot(axisOver.axis);
 
-                                if (!MathUtils.sameSign(resolutionPosition, lastPosition) || Math.abs(lastPosition) < Math.abs(resolutionPosition)) {
+                                if (!MathUtils.sameSign(resolutionPosition, lastPosition) || (lastPosition < resolutionPosition)) {
                                     validCollision = false;
                                 }
                             }

--- a/jump-core/src/main/java/com/bitdecay/jump/level/FileUtils.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/FileUtils.java
@@ -71,7 +71,12 @@ public class FileUtils {
 	}
 
 	public static <T> T loadFileAs(Class<T> clazz) {
-		return loadFileAs(clazz, loadFile());
+		String file = loadFile();
+		if (file == null || file.length() <= 0) {
+			return null;
+		} else {
+			return loadFileAs(clazz, file);
+		}
 	}
 
 	public static <T> T loadFileAs(Class<T> clazz, File file) {

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelBuilder.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelBuilder.java
@@ -198,41 +198,66 @@ public class LevelBuilder {
 	}
 
 	private void updateNeighbors(int x, int y) {
+		updateOwnNeighbors(x, y);
+
+		updateOwnNeighbors(x+1, y);
+		updateOwnNeighbors(x-1, y);
+		updateOwnNeighbors(x, y+1);
+		updateOwnNeighbors(x, y-1);
+	}
+
+	public void updateOwnNeighbors(int x, int y) {
+		if (!ArrayUtilities.onGrid(grid, x, y) || grid[x][y] == null) {
+			return;
+		}
+
 		// check right
-		if (ArrayUtilities.onGrid(grid, x + 1, y) && grid[x + 1][y] != null && !grid[x + 1][y].oneway) {
-			if (grid[x][y] == null) {
-				grid[x + 1][y].nValue &= Direction.NOT_LEFT;
+		if (ArrayUtilities.onGrid(grid, x + 1, y) && grid[x + 1][y] != null) {
+			if (grid[x+1][y].oneway) {
+				grid[x][y].collideNValue &= Direction.NOT_RIGHT;
 			} else {
-				grid[x][y].nValue |= Direction.RIGHT;
-				grid[x + 1][y].nValue |= Direction.LEFT;
+				grid[x][y].collideNValue |= Direction.RIGHT;
 			}
+			grid[x][y].renderNValue |= Direction.RIGHT;
+		} else {
+			grid[x][y].collideNValue &= Direction.NOT_RIGHT;
+			grid[x][y].renderNValue &= Direction.NOT_RIGHT;
 		}
 		// check left
-		if (ArrayUtilities.onGrid(grid, x - 1, y) && grid[x - 1][y] != null && !grid[x - 1][y].oneway) {
-			if (grid[x][y] == null) {
-				grid[x - 1][y].nValue &= Direction.NOT_RIGHT;
+		if (ArrayUtilities.onGrid(grid, x - 1, y) && grid[x - 1][y] != null) {
+			if (grid[x-1][y].oneway) {
+				grid[x][y].collideNValue &= Direction.NOT_LEFT;
 			} else {
-				grid[x][y].nValue |= Direction.LEFT;
-				grid[x - 1][y].nValue |= Direction.RIGHT;
+				grid[x][y].collideNValue |= Direction.LEFT;
 			}
+			grid[x][y].renderNValue |= Direction.LEFT;
+		} else {
+			grid[x][y].collideNValue &= Direction.NOT_LEFT;
+			grid[x][y].renderNValue &= Direction.NOT_LEFT;
 		}
 		// check up
-		if (ArrayUtilities.onGrid(grid, x, y + 1) && grid[x][y + 1] != null && !grid[x][y + 1].oneway) {
-			if (grid[x][y] == null) {
-				grid[x][y + 1].nValue &= Direction.NOT_DOWN;
+		if (ArrayUtilities.onGrid(grid, x, y + 1) && grid[x][y + 1] != null) {
+			if (grid[x][y+1].oneway) {
+				grid[x][y].collideNValue &= Direction.NOT_UP;
 			} else {
-				grid[x][y].nValue |= Direction.UP;
-				grid[x][y + 1].nValue |= Direction.DOWN;
+				grid[x][y].collideNValue |= Direction.UP;
 			}
+			grid[x][y].renderNValue |= Direction.UP;
+		} else {
+			grid[x][y].collideNValue &= Direction.NOT_UP;
+			grid[x][y].renderNValue &= Direction.NOT_UP;
 		}
 		// check down
-		if (ArrayUtilities.onGrid(grid, x, y - 1) && grid[x][y - 1] != null && !grid[x][y - 1].oneway) {
-			if (grid[x][y] == null) {
-				grid[x][y - 1].nValue &= Direction.NOT_UP;
+		if (ArrayUtilities.onGrid(grid, x, y - 1) && grid[x][y - 1] != null) {
+			if (grid[x][y-1].oneway) {
+				grid[x][y].collideNValue &= Direction.NOT_DOWN;
 			} else {
-				grid[x][y].nValue |= Direction.DOWN;
-				grid[x][y - 1].nValue |= Direction.UP;
+				grid[x][y].collideNValue |= Direction.DOWN;
 			}
+			grid[x][y].renderNValue |= Direction.DOWN;
+		} else {
+			grid[x][y].collideNValue &= Direction.NOT_DOWN;
+			grid[x][y].renderNValue &= Direction.NOT_DOWN;
 		}
 	}
 

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/TileObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/TileObject.java
@@ -12,7 +12,9 @@ public class TileObject extends LevelObject {
 	/** Rendering hint for which tile to use
 	 * Based on bitwise values specified in {@link com.bitdecay.jump.level.Direction}
 	 */
-	public int nValue;
+	public int renderNValue;
+
+	public int collideNValue;
 
 	public boolean oneway;
 
@@ -28,12 +30,10 @@ public class TileObject extends LevelObject {
 
 	@Override
 	public BitBody buildBody() {
-		// tile objects don't need a body.
-		// CONSIDER: we might want to just put the collision shit (nValue) onto the body
 		TileBody body = new TileBody();
 		body.material = material;
 		body.aabb = rect.copyOf();
-		body.nValue = nValue;
+		body.nValue = collideNValue;
 		body.bodyType = BodyType.STATIC;
 		if (oneway) {
 			body.collisionAxis = GeomUtils.Y_AXIS;

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/Launcher.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/Launcher.java
@@ -11,5 +11,4 @@ public class Launcher {
         config.height = 900;
         new LwjglApplication(new TestApp(), config);
     }
-
 }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
@@ -1,7 +1,6 @@
 package com.bitdecay.jump.leveleditor.example;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -82,7 +81,7 @@ public class ExampleEditorLevel implements EditorHook {
             for (int y = 0; y < currentLevel.gridObjects[0].length; y++) {
                 TileObject obj = currentLevel.gridObjects[x][y];
                 if (obj != null) {
-                    batch.draw(tilesetMap.get(obj.material)[obj.nValue], obj.rect.xy.x, obj.rect.xy.y, obj.rect.width, obj.rect.height);
+                    batch.draw(tilesetMap.get(obj.material)[obj.renderNValue], obj.rect.xy.x, obj.rect.xy.y, obj.rect.width, obj.rect.height);
                 }
             }
         }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
@@ -408,19 +408,6 @@ public class LevelEditor extends InputAdapter implements Screen, OptionsUICallba
         }
     }
 
-    public void saveLevel() {
-        LevelUtilities.saveLevel(curLevelBuilder);
-    }
-
-    public void loadLevel() {
-        Level loadLevel = LevelUtilities.loadLevel();
-        if (loadLevel != null) {
-            setLevelBuilder(loadLevel);
-            setCamToOrigin();
-            stepWorld = false;
-        }
-    }
-
     private void saveProps() {
         BitBody player = maybeGetPlayer();
         if (player != null) {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LibGDXWorldRenderer.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LibGDXWorldRenderer.java
@@ -49,9 +49,13 @@ public class LibGDXWorldRenderer implements BitWorldRenderer {
                     }
                     if (((TileBody) levelObject).collisionAxis != null) {
                         // currently we are just assuming it's a one-way platform
+                        renderer.setColor(BitColors.COLLISION);
                         renderer.line(leftX, topY, rightX, topY);
                         continue;
+                    } else {
+                        renderer.setColor(BitColors.STATIC_OBJECT);
                     }
+
 
                     if ((nValue & Direction.UP) == 0) {
                         renderer.line(leftX, topY, rightX, topY);

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/SpawnMouseMode.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/SpawnMouseMode.java
@@ -15,7 +15,7 @@ public class SpawnMouseMode extends BaseMouseMode {
 
     @Override
     protected void mouseUpLogic(BitPointInt point, MouseButton button) {
-        builder.setSpawn(point);
+         builder.setSpawn(point);
     }
 
     @Override

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/menus/EditorMenus.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/menus/EditorMenus.java
@@ -64,6 +64,7 @@ public class EditorMenus {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 topMenuTransition(MenuPage.CreateMenu);
+                levelEditor.setMode(OptionsMode.SELECT);
             }
         });
         menu.add(toolsBtn).height(30);
@@ -161,7 +162,15 @@ public class EditorMenus {
             }
         }
 
-        addBackButtonAndFinalizeMenu(menu, MenuPage.MainMenu);
+        addBackButtonAndFinalizeMenu(menu, new ClickListener() {
+            @Override
+            public void clicked(InputEvent event, float x, float y) {
+                topMenuTransition(MenuPage.MainMenu);
+                rightMenuTransition(null);
+                levelEditor.setMode(OptionsMode.SELECT);
+                createGroup.setChecked(OptionsMode.SELECT.label);
+            }
+        });
         return menu;
     }
 
@@ -183,7 +192,16 @@ public class EditorMenus {
             }
         }
 
-        addBackButtonAndFinalizeMenu(menu, MenuPage.MainMenu);
+        addBackButtonAndFinalizeMenu(menu, new ClickListener() {
+                    @Override
+                    public void clicked(InputEvent event, float x, float y) {
+                        topMenuTransition(MenuPage.MainMenu);
+                        rightMenuTransition(null);
+                        levelEditor.setMode(OptionsMode.SELECT);
+                    }
+                });
+
+
         return menu;
     }
 
@@ -273,17 +291,10 @@ public class EditorMenus {
         return parentMenu;
     }
 
-    private void addBackButtonAndFinalizeMenu(Table menu, MenuPage backTo) {
+    private void addBackButtonAndFinalizeMenu(Table menu, ClickListener backAction) {
         TextButton backBtn;
         backBtn = new TextButton("back", skin, "button");
-        backBtn.addListener(new ClickListener() {
-            @Override
-            public void clicked(InputEvent event, float x, float y) {
-                topMenuTransition(backTo);
-                rightMenuTransition(null);
-                levelEditor.setMode(OptionsMode.SELECT);
-            }
-        });
+        backBtn.addListener(backAction);
         menu.add(backBtn).height(30);
         menu.align(Align.topLeft);
         menu.setFillParent(true);


### PR DESCRIPTION
Fixes #58

This fixed a bug hiding in one way platforms that caused them to only work in positive y coordinates. That's fixed now.

UI is cleaned up just a little bit.

There are now 2 neighbor values: one for rendering and one for collisions.