### PR TITLE
Fix Drop Object tool

### DIFF
--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/DropObjectMode.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/DropObjectMode.java
@@ -48,8 +48,10 @@ public class DropObjectMode extends BaseMouseMode{
 
     @Override
     protected void mouseUpLogic(BitPointInt point, MouseButton button) {
-        builder.createObject(objectClass, currentLocation);
-        editor.setMode(OptionsMode.SELECT);
+        if (reference != null) {
+            builder.createObject(objectClass, currentLocation);
+            reference = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Make sure after you drop an object, it clears the tool until you select another one. This is the best of what we have until we come up with a better strategy for this tool (better simple than over complicated for the time being)