### PR TITLE
More collision resolution rework. This one might be dangerous but...

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/collision/SATResolution.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/SATResolution.java
@@ -59,41 +59,37 @@ public class SATResolution {
             dotProd = relativeMovement.dot(axisOver.axis);
             if (dotProd != 0 && !MathUtils.sameSign(dotProd, axisOver.distance)) {
                 if (otherBody instanceof TileBody) {
-                    boolean validCollision = true;
                     if (!axisValidForNValue(axisOver, (TileBody) otherBody)) {
                         continue;
                     }
+                    // confirm that body came from past this thing
+                    float resolutionPosition = body.aabb.xy.plus(axisOver.axis.times(axisOver.distance)).dot(axisOver.axis);
+                    float lastPosition = body.lastPosition.dot(axisOver.axis);
+
+                    if (!MathUtils.sameSign(resolutionPosition, lastPosition)) {
+                        continue;
+                    }
+
+                    if (axisOver.distance < 0 && (lastPosition > resolutionPosition)) {
+                        continue;
+                    }
+
+                    if (axisOver.distance > 0 && lastPosition < resolutionPosition) {
+                        continue;
+                    }
+
                     if (((TileBody) otherBody).collisionAxis != null) {
                         if (axisOver.axis.equals(((TileBody) otherBody).collisionAxis)) {
                             if (axisOver.distance < 0) {
-                                validCollision = false;
-                            } else {
-                                // confirm that body came from past this thing
-                                float resolutionPosition = body.aabb.xy.plus(axisOver.axis.times(axisOver.distance)).dot(axisOver.axis);
-                                float lastPosition = body.lastPosition.dot(axisOver.axis);
-
-                                if (!MathUtils.sameSign(resolutionPosition, lastPosition) || (lastPosition < resolutionPosition)) {
-                                    validCollision = false;
-                                }
+                                continue;
                             }
                         } else if (axisOver.axis.equals(((TileBody) otherBody).collisionAxis.times(-1))) {
                             if (axisOver.distance > 0) {
-                                validCollision = false;
-                            } else {
-                                // confirm that body came from past this thing
-                                float resolutionPosition = body.aabb.xy.plus(axisOver.axis.times(axisOver.distance)).dot(axisOver.axis);
-                                float lastPosition = body.lastPosition.dot(axisOver.axis);
-
-                                if (!MathUtils.sameSign(resolutionPosition, lastPosition) || Math.abs(lastPosition) > Math.abs(resolutionPosition)) {
-                                    validCollision = false;
-                                }
+                                continue;
                             }
                         } else {
-                            validCollision = false;
+                            continue;
                         }
-                    }
-                    if (!validCollision) {
-                        continue;
                     }
                 }
                 axis = axisOver.axis;

--- a/jump-core/src/main/java/com/bitdecay/jump/state/AbstractStateWatcher.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/state/AbstractStateWatcher.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public abstract class AbstractStateWatcher implements BitBodyStateWatcher {
 	private List<StateListener> listeners = new ArrayList<StateListener>();
-	protected State state;
+	protected State state = JumperState.RIGHT_STANDING;
 
 	@Override
 	public void addListener(StateListener listener) {


### PR DESCRIPTION
…it looked to perform well.

Fixes #82 

Basically this change makes it so only resolutions that push you out from a given axis are considered valid. Effectively just made the logic I did for one-way's into a generic chunk of math that now applies to all collisions.