### PR TITLE
Moving platform optimize

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
@@ -15,6 +15,8 @@ public class PathedBodyController implements BitBodyController{
 
     private float pause;
 
+    private float extraPercent;
+
     int index;
     boolean forward;
     PathPoint targetPoint;
@@ -37,20 +39,18 @@ public class PathedBodyController implements BitBodyController{
             if (targetPoint == null) {
                 targetPoint = pickNextPathPoint(true);
             }
-            BitPoint difference = targetPoint.destination.minus(body.aabb.xy);
-            float distanceToGo = Math.abs(difference.len());
+            BitPoint distanceToDestination = targetPoint.destination.minus(body.aabb.xy);
+            float distanceToGo = Math.abs(distanceToDestination.len());
             float travelThisFrame = targetPoint.speed * delta;
             if (distanceToGo < travelThisFrame) {
                 // Find how far along the next path we should have moved because of overshooting our current target
-                float remainder = travelThisFrame - distanceToGo;
-                float percent = remainder / travelThisFrame;
-                float normalizedTravel = pickNextPathPoint(false).speed * delta * percent;
-                BitPoint trueMovement = difference.plus(pickNextPathPoint(false).destination.minus(targetPoint.destination).normalize().scale(normalizedTravel));
-                body.velocity.set(trueMovement.scale(1 / delta));
+                float distanceOvershot = travelThisFrame - distanceToGo;
+                extraPercent = distanceOvershot / travelThisFrame;
+                body.velocity.set(distanceToDestination.scale(1 / delta));
                 pause = targetPoint.stayTime;
                 targetPoint = null;
             } else {
-                body.velocity.set(difference.normalize().scale(targetPoint.speed));
+                body.velocity.set(distanceToDestination.normalize().scale(targetPoint.speed + targetPoint.speed * extraPercent));
             }
         }
     }

--- a/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
@@ -57,6 +57,7 @@ public class PathedBodyController implements BitBodyController{
                 targetPoint = null;
             } else {
                 body.velocity.set(distanceToDestination.normalize().scale(targetPoint.speed * (1 + extraPercent)));
+                extraPercent = 0;
             }
         }
     }

--- a/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
@@ -50,7 +50,7 @@ public class PathedBodyController implements BitBodyController{
                 pause = targetPoint.stayTime;
                 targetPoint = null;
             } else {
-                body.velocity.set(distanceToDestination.normalize().scale(targetPoint.speed + targetPoint.speed * extraPercent));
+                body.velocity.set(distanceToDestination.normalize().scale(targetPoint.speed * (1 + extraPercent)));
             }
         }
     }

--- a/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/controller/PathedBodyController.java
@@ -1,6 +1,7 @@
 package com.bitdecay.jump.controller;
 
 import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.collision.BitWorld;
 import com.bitdecay.jump.geom.BitPoint;
 import com.bitdecay.jump.geom.PathPoint;
 
@@ -46,7 +47,12 @@ public class PathedBodyController implements BitBodyController{
                 // Find how far along the next path we should have moved because of overshooting our current target
                 float distanceOvershot = travelThisFrame - distanceToGo;
                 extraPercent = distanceOvershot / travelThisFrame;
-                body.velocity.set(distanceToDestination.scale(1 / delta));
+                /**
+                 * We set velocity instead of position so the engine can do the actual move. But in doing this
+                 * we have to adjust the velocity based on the delta to make sure we move the right distance
+                 * next update.
+                 */
+                body.velocity.set(distanceToDestination.scale(BitWorld.STEP_PER_SEC));
                 pause = targetPoint.stayTime;
                 targetPoint = null;
             } else {


### PR DESCRIPTION
Fixes #98 

Changed how moving platforms work from:

If a platform overshoots its target, it moves down the next edge of its path an appropriate amount.

To:

If a platform were to overshoot its target, it aims to move exactly to it's target and stores an extra percentage to move NEXT update to compensate.


This ensures that platforms always stop at each node point, but catch up the next frame to make sure things stay in sync.