### PR TITLE
Wall slide speed. Refactor jumper properties into their own object

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/JumperBody.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/JumperBody.java
@@ -1,10 +1,14 @@
 package com.bitdecay.jump;
 
+import com.bitdecay.jump.properties.JumperProperties;
+
 /**
  * A specialized body that holds state information specific to something platformer bodies
  * Created by Monday on 11/5/2015.
  */
 public class JumperBody extends BitBody {
+    public JumperProperties jumperProps;
+
     /**
      *
      */

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/FallingControlState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/FallingControlState.java
@@ -13,13 +13,10 @@ public class FallingControlState extends SidewaysControlState {
     float preJumpTimer;
     boolean waitingForRelease;
 
-    JumperProperties props;
-
     @Override
     public void stateEntered(JumperBody body, ControlMap controls) {
         waitingForRelease = controls.isPressed(PlayerAction.JUMP);
         preJumpTimer = 0;
-        props = (JumperProperties) body.props;
     }
 
     @Override
@@ -33,14 +30,14 @@ public class FallingControlState extends SidewaysControlState {
             waitingForRelease = false;
         }
 
-        if (props.wallSlideEnabled && BitWorld.gravity.dot(body.currentAttempt) > 0 && body.lastResolution.x != 0) {
+        if (body.jumperProps.wallSlideEnabled && BitWorld.gravity.dot(body.currentAttempt) > 0 && body.lastResolution.x != 0) {
             return new WallSlideState();
         }
 
         handleLeftRight(delta, body, controls, body.props.airAcceleration, body.props.airDeceleration);
 
         if (body.grounded) {
-            if (!waitingForRelease && controls.isPressed(PlayerAction.JUMP) && preJumpTimer <= ((JumperProperties)body.props).jumpGraceWindow) {
+            if (!waitingForRelease && controls.isPressed(PlayerAction.JUMP) && preJumpTimer <= body.jumperProps.jumpGraceWindow) {
                 body.bunnyHop = true;
             }
             return new GroundedControlState();

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/GroundedControlState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/GroundedControlState.java
@@ -14,7 +14,7 @@ public class GroundedControlState extends SidewaysControlState {
     @Override
     public void stateEntered(JumperBody body, ControlMap controls) {
         body.jumpsPerformed = 0;
-        body.jumpsRemaining = ((JumperProperties)body.props).jumpCount;
+        body.jumpsRemaining = body.jumperProps.jumpCount;
     }
 
     @Override
@@ -29,15 +29,9 @@ public class GroundedControlState extends SidewaysControlState {
     }
 
     private JumperBodyControlState checkStateChange(float delta, JumperBody body, ControlMap controls) {
-        JumperProperties props;
-        if (body.props instanceof JumperProperties) {
-            props = (JumperProperties) body.props;
-        } else {
-            return this;
-        }
         if (!body.grounded) {
             jumpGracePeriod += delta;
-            if (jumpGracePeriod > props.jumpGraceWindow) {
+            if (jumpGracePeriod > body.jumperProps.jumpGraceWindow) {
                 body.jumpsRemaining--;
                 return new FallingControlState();
             }

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/JumpingControlState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/JumpingControlState.java
@@ -32,18 +32,11 @@ public class JumpingControlState extends SidewaysControlState {
     public JumperBodyControlState update(float delta, JumperBody body, ControlMap controls) {
 
         handleLeftRight(delta, body, controls, body.props.airAcceleration, body.props.airDeceleration);
-        JumperProperties props;
-        if (body.props instanceof JumperProperties) {
-            props = (JumperProperties) body.props;
-        } else {
-            return this;
-        }
-
-        if (props.wallSlideEnabled && BitWorld.gravity.dot(body.currentAttempt) > 0 && body.lastResolution.x != 0) {
+        if (body.jumperProps.wallSlideEnabled && BitWorld.gravity.dot(body.currentAttempt) > 0 && body.lastResolution.x != 0) {
             return new WallSlideState();
         }
 
-        if (props.jumpHittingHeadStopsJump){
+        if (body.jumperProps.jumpHittingHeadStopsJump){
             if (BitWorld.gravity.dot(body.lastResolution) > 0) {
                 return new FallingControlState();
             }
@@ -51,12 +44,12 @@ public class JumpingControlState extends SidewaysControlState {
 
         if (firstUpdate || !body.grounded) {
             firstUpdate = false;
-            if (controls.isPressed(PlayerAction.JUMP) && jumpVariableHeightWindow <= props.jumpVariableHeightWindow) {
-                if (body.jumpsRemaining == ((JumperProperties) body.props).jumpCount) {
+            if (controls.isPressed(PlayerAction.JUMP) && jumpVariableHeightWindow <= body.jumperProps.jumpVariableHeightWindow) {
+                if (body.jumpsRemaining == body.jumperProps.jumpCount) {
                     // first jump
-                    body.velocity.y = props.jumpStrength * (MathUtils.sameSign(BitWorld.gravity.y, props.jumpStrength) ? -1 : 1);
+                    body.velocity.y = body.jumperProps.jumpStrength * (MathUtils.sameSign(BitWorld.gravity.y, body.jumperProps.jumpStrength) ? -1 : 1);
                 } else {
-                    body.velocity.y = props.jumpDoubleJumpStrength * (MathUtils.sameSign(BitWorld.gravity.y, props.jumpDoubleJumpStrength) ? -1 : 1);
+                    body.velocity.y = body.jumperProps.jumpDoubleJumpStrength * (MathUtils.sameSign(BitWorld.gravity.y, body.jumperProps.jumpDoubleJumpStrength) ? -1 : 1);
                 }
                 jumpVariableHeightWindow += delta;
                 return this;

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/WallSlideState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/WallSlideState.java
@@ -48,6 +48,11 @@ public class WallSlideState implements JumperBodyControlState {
                 return new FallingControlState();
             }
             body.velocity.x = directionOfWall;
+            if (body.jumperProps.wallMaxSlideSpeed == 0) {
+                body.velocity.y = 0;
+            } else if (body.jumperProps.wallMaxSlideSpeed > 0) {
+                body.velocity.y = Math.max(body.velocity.y, -body.jumperProps.wallMaxSlideSpeed);
+            }
             return this;
         }
     }

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/WallSlideState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/WallSlideState.java
@@ -16,14 +16,11 @@ public class WallSlideState implements JumperBodyControlState {
     boolean wallLeft;
     int directionOfWall;
 
-    JumperProperties props;
-
     @Override
     public void stateEntered(JumperBody body, ControlMap controls) {
         wallLeft =  body.lastResolution.x > 0;
         directionOfWall = wallLeft ? -force_into_wall : force_into_wall;
         body.velocity.x = directionOfWall;
-        props = (JumperProperties) body.props;
     }
 
     @Override
@@ -42,8 +39,8 @@ public class WallSlideState implements JumperBodyControlState {
                 return new FallingControlState();
             }
 
-            if (props.wallJumpEnabled && controls.isJustPressed(PlayerAction.JUMP)) {
-                body.velocity.x = props.wallJumpLaunchPower * (wallLeft ? 1 : -1);
+            if (body.jumperProps.wallJumpEnabled && controls.isJustPressed(PlayerAction.JUMP)) {
+                body.velocity.x = body.jumperProps.wallJumpLaunchPower * (wallLeft ? 1 : -1);
                 return new JumpingControlState();
             }
 

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/SpawnObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/SpawnObject.java
@@ -3,6 +3,7 @@ package com.bitdecay.jump.level.builder;
 import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.geom.BitPointInt;
 import com.bitdecay.jump.geom.BitRectangle;
+import com.bitdecay.jump.properties.BitBodyProperties;
 import com.bitdecay.jump.properties.JumperProperties;
 
 /**
@@ -12,7 +13,8 @@ public class SpawnObject extends LevelObject{
     public static final int INNER_DIAMETER = 4;
     public static final int OUTER_DIAMETER = 8;
 
-    public JumperProperties props;
+    public BitBodyProperties props;
+    public JumperProperties jumpProps;
 
     public SpawnObject() {
         // Here for JSON
@@ -22,18 +24,21 @@ public class SpawnObject extends LevelObject{
         super(new BitRectangle(point, point));
 
         // filler for now. Eventually the UI will let this be loaded/saved/tweaked
-        JumperProperties props = new JumperProperties();
+        BitBodyProperties props = new BitBodyProperties();
         props.airAcceleration.set(600, 0);
         props.airDeceleration.set(300, 0);
         props.acceleration.set(600, 0);
         props.deceleration.set(300, 0);
-        props.jumpCount = 2;
-        props.jumpStrength = 300;
-        props.jumpDoubleJumpStrength = 150;
-        props.jumpVariableHeightWindow = .2f;
-        props.jumpGraceWindow = .2f;
-        props.jumpHittingHeadStopsJump = true;
         this.props = props;
+
+        JumperProperties jumpProps = new JumperProperties();
+        jumpProps.jumpCount = 2;
+        jumpProps.jumpStrength = 300;
+        jumpProps.jumpDoubleJumpStrength = 150;
+        jumpProps.jumpVariableHeightWindow = .2f;
+        jumpProps.jumpGraceWindow = .2f;
+        jumpProps.jumpHittingHeadStopsJump = true;
+        this.jumpProps = jumpProps;
     }
 
     /**

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
@@ -51,4 +51,9 @@ public class JumperProperties {
      * How hard a body jumps off the wall when performing a wall jump
      */
     public int wallJumpLaunchPower;
+
+    /**
+     * The maximum speed at which a a body can slide down a wall
+     */
+    public int wallMaxSlideSpeed;
 }

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
@@ -3,7 +3,7 @@ package com.bitdecay.jump.properties;
 /**
  * Created by Monday on 10/25/2015.
  */
-public class JumperProperties extends BitBodyProperties {
+public class JumperProperties {
     /**
      * The number of jumps a body can make before needing to touch the ground again
      */

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
@@ -142,6 +142,7 @@ public class ExampleEditorLevel implements EditorHook {
         if (level.spawn != null) {
             JumperBody playerBody = new JumperBody();
             playerBody.props = level.spawn.props;
+            playerBody.jumperProps = level.spawn.jumpProps;
 
             playerBody.bodyType = BodyType.DYNAMIC;
             playerBody.aabb = new BitRectangle(level.spawn.rect.xy.x,level.spawn.rect.xy.y,16,32);


### PR DESCRIPTION
I feel like this should make things easier to maintain down the road, though it seems a little odd possibly.

This has basically pulled out all properties specific to a 'jumper body' into its own supplement class rather than extending the base properties class. Removes all the stupid casting stuff I was doing.

__NOTE__
This change will break any previously saved levels, so if we gunna do it, we might as well do it now before we actually make anything with this engine.


Now this fixes #78, also. DEAL WITH IT.