### PR TITLE
Annotation driven inspection. Persistence of property objects

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/annotation/CanLoadFromFile.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/annotation/CanLoadFromFile.java
@@ -1,0 +1,11 @@
+package com.bitdecay.jump.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by Monday on 11/8/2015.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CanLoadFromFile {
+}

--- a/jump-core/src/main/java/com/bitdecay/jump/annotation/CantInspect.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/annotation/CantInspect.java
@@ -1,0 +1,11 @@
+package com.bitdecay.jump.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by Monday on 11/8/2015.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CantInspect {
+}

--- a/jump-core/src/main/java/com/bitdecay/jump/annotation/ValueRange.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/annotation/ValueRange.java
@@ -1,0 +1,13 @@
+package com.bitdecay.jump.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by Monday on 11/8/2015.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValueRange {
+    int min();
+    int max();
+}

--- a/jump-core/src/main/java/com/bitdecay/jump/control/PlayerInputController.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/PlayerInputController.java
@@ -2,12 +2,13 @@ package com.bitdecay.jump.control;
 
 import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.JumperBody;
+import com.bitdecay.jump.control.state.FallingControlState;
 import com.bitdecay.jump.control.state.GroundedControlState;
 import com.bitdecay.jump.control.state.JumperBodyControlState;
 
 public class PlayerInputController implements BitBodyController {
     private ControlMap controls;
-    private JumperBodyControlState state = new GroundedControlState();
+    private JumperBodyControlState state = new FallingControlState();
 
     public PlayerInputController(ControlMap controls) {
         this.controls = controls;

--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/SidewaysControlState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/SidewaysControlState.java
@@ -10,7 +10,7 @@ import com.bitdecay.jump.geom.BitPoint;
  * Created by Monday on 11/4/2015.
  */
 public abstract class SidewaysControlState implements JumperBodyControlState {
-    protected void handleLeftRight(float delta, BitBody body, ControlMap controls, BitPoint accel, BitPoint decel) {
+    protected void handleLeftRight(float delta, BitBody body, ControlMap controls, int accel, int decel) {
         boolean requestLeft = controls.isPressed(PlayerAction.LEFT);
         boolean requestRight = controls.isPressed(PlayerAction.RIGHT);
 
@@ -18,36 +18,36 @@ public abstract class SidewaysControlState implements JumperBodyControlState {
             body.facing = requestLeft ? Facing.LEFT : Facing.RIGHT;
             if (requestLeft) {
                 if (body.velocity.x > 0) {
-                    if (decel.x == 0) {
+                    if (decel == 0) {
                         body.velocity.x = 0;
                     }
-                    body.velocity.x = accel.x == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
-                            - (accel.x + decel.x) * delta);
+                    body.velocity.x = accel == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
+                            - (accel + decel) * delta);
                 } else {
-                    body.velocity.x = accel.x == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
-                            - accel.x * delta);
+                    body.velocity.x = accel == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
+                            - accel * delta);
                 }
             } else {
                 if (body.velocity.x > 0) {
-                    body.velocity.x = accel.x == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
-                            + accel.x * delta);
+                    body.velocity.x = accel == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
+                            + accel * delta);
                 } else {
-                    if (decel.x == 0) {
+                    if (decel == 0) {
                         body.velocity.x = 0;
                     }
-                    body.velocity.x = accel.x == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
-                            + (accel.x + decel.x) * delta);
+                    body.velocity.x = accel == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
+                            + (accel + decel) * delta);
                 }
             }
         } else {
-            if (decel.x == 0) {
+            if (decel == 0) {
                 body.velocity.x = 0;
             } else {
                 if (body.velocity.x > 0) {
-                    body.velocity.x = Math.max(0, body.velocity.x - decel.x * delta);
+                    body.velocity.x = Math.max(0, body.velocity.x - decel * delta);
                 }
                 if (body.velocity.x < 0) {
-                    body.velocity.x = Math.min(0, body.velocity.x + decel.x * delta);
+                    body.velocity.x = Math.min(0, body.velocity.x + decel * delta);
                 }
             }
         }

--- a/jump-core/src/main/java/com/bitdecay/jump/level/FileUtils.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/FileUtils.java
@@ -88,7 +88,6 @@ public class FileUtils {
 			e.printStackTrace();
 			return null;
 		}
-		//		return new GsonBuilder().create().fromJson(json, clazz);
 	}
 
 	public static String loadFile() {

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/DebugSpawnObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/DebugSpawnObject.java
@@ -1,6 +1,7 @@
 package com.bitdecay.jump.level.builder;
 
 import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.annotation.CanLoadFromFile;
 import com.bitdecay.jump.geom.BitPointInt;
 import com.bitdecay.jump.geom.BitRectangle;
 import com.bitdecay.jump.properties.BitBodyProperties;
@@ -13,17 +14,19 @@ public class DebugSpawnObject extends LevelObject{
     public static final int INNER_DIAMETER = 4;
     public static final int OUTER_DIAMETER = 8;
 
+    @CanLoadFromFile
     public BitBodyProperties props;
+    @CanLoadFromFile
     public JumperProperties jumpProps;
 
     public DebugSpawnObject(BitPointInt point) {
         super(new BitRectangle(point, point));
 
         props = new BitBodyProperties();
-        props.airAcceleration.set(600, 0);
-        props.airDeceleration.set(300, 0);
-        props.acceleration.set(600, 0);
-        props.deceleration.set(300, 0);
+        props.airAcceleration = 600;
+        props.airDeceleration = 300;
+        props.acceleration = 600;
+        props.deceleration = 300;
 
         jumpProps = new JumperProperties();
         jumpProps.jumpCount = 2;

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/LevelObject.java
@@ -1,10 +1,12 @@
 package com.bitdecay.jump.level.builder;
 
 import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.annotation.CantInspect;
 import com.bitdecay.jump.geom.BitRectangle;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public abstract class LevelObject {
+	@CantInspect
 	public BitRectangle rect;
 
 	public LevelObject() {

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/TileObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/TileObject.java
@@ -2,18 +2,22 @@ package com.bitdecay.jump.level.builder;
 
 import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.BodyType;
+import com.bitdecay.jump.annotation.CantInspect;
 import com.bitdecay.jump.geom.BitRectangle;
 import com.bitdecay.jump.geom.GeomUtils;
 import com.bitdecay.jump.level.TileBody;
 
 public class TileObject extends LevelObject {
+	@CantInspect
 	public int material;
 
 	/** Rendering hint for which tile to use
 	 * Based on bitwise values specified in {@link com.bitdecay.jump.level.Direction}
 	 */
+	@CantInspect
 	public int renderNValue;
 
+	@CantInspect
 	public int collideNValue;
 
 	public boolean oneway;

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
@@ -1,5 +1,6 @@
 package com.bitdecay.jump.properties;
 
+import com.bitdecay.jump.annotation.ValueRange;
 import com.bitdecay.jump.geom.BitPoint;
 
 /**
@@ -10,22 +11,26 @@ public class BitBodyProperties {
     /**
      * The acceleration of the body while on the ground
      */
-    public BitPoint acceleration = new BitPoint(0, 0);
+    @ValueRange(min = 0, max = 5000)
+    public int acceleration = 0;
 
     /**
      * The Deceleration of the body while in the air
      */
-    public BitPoint airAcceleration = new BitPoint(0, 0);
+    @ValueRange(min = 0, max = 5000)
+    public int airAcceleration = 0;
 
     /**
      * The decelleration of the body on while on the ground
      */
-    public BitPoint deceleration = new BitPoint(0, 0);
+    @ValueRange(min = 0, max = 5000)
+    public int deceleration = 0;
 
     /**
      * The Acceleration of the body while in the air
      */
-    public BitPoint airDeceleration = new BitPoint(0, 0);
+    @ValueRange(min = 0, max = 5000)
+    public int airDeceleration = 0;
 
     /**
      * The max speed of the body
@@ -37,5 +42,6 @@ public class BitBodyProperties {
      */
     public boolean gravitational = true;
 
+    @ValueRange(min = 0, max = 10)
     public float gravityModifier = 1.0f;
 }

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/JumperProperties.java
@@ -1,5 +1,7 @@
 package com.bitdecay.jump.properties;
 
+import com.bitdecay.jump.annotation.ValueRange;
+
 /**
  * Created by Monday on 10/25/2015.
  */
@@ -7,21 +9,25 @@ public class JumperProperties {
     /**
      * The number of jumps a body can make before needing to touch the ground again
      */
+    @ValueRange(min = 0, max = 10)
     public int jumpCount = 2;
 
     /**
      * The jump strength of the primary jump
      */
+    @ValueRange(min = 0, max = 1000)
     public int jumpStrength = 300;
 
     /**
      * The jump strength of any jump after the first
      */
+    @ValueRange(min = 0, max = 1000)
     public int jumpDoubleJumpStrength = 150;
 
     /**
      * The window, in seconds, that holding the jump button can increase jump height
      */
+    @ValueRange(min = 0, max = 2)
     public float jumpVariableHeightWindow = .2f;
 
     /**
@@ -29,6 +35,7 @@ public class JumperProperties {
      *  - jump early before actually becoming grounded
      *  - jump after running off a ledge
      */
+    @ValueRange(min = 0, max = 1)
     public float jumpGraceWindow = .2f;
 
     /**
@@ -50,10 +57,12 @@ public class JumperProperties {
     /**
      * How hard a body jumps off the wall when performing a wall jump
      */
+    @ValueRange(min = 0, max = 1000)
     public int wallJumpLaunchPower;
 
     /**
      * The maximum speed at which a a body can slide down a wall
      */
+    @ValueRange(min = 0, max = 500)
     public int wallMaxSlideSpeed;
 }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/SecretThing.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/SecretThing.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.BodyType;
+import com.bitdecay.jump.annotation.CantInspect;
 import com.bitdecay.jump.gdx.level.RenderableLevelObject;
 import com.bitdecay.jump.geom.BitRectangle;
 import com.bitdecay.jump.level.builder.LevelObject;
@@ -15,6 +16,7 @@ import com.bitdecay.jump.leveleditor.render.LevelEditor;
  */
 // make this object specify a class that it is? does that make any sense?
 public class SecretThing extends RenderableLevelObject {
+    @CantInspect
     private TextureRegion texture;
 
     public SecretThing() {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/PropModUI.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/PropModUI.java
@@ -5,11 +5,6 @@ import com.bitdecay.jump.leveleditor.ui.component.ComponentBuilderFactory;
 
 import javax.swing.*;
 import java.awt.*;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
 
 public class PropModUI extends JDialog {
     private static final long serialVersionUID = 1L;
@@ -40,7 +35,7 @@ public class PropModUI extends JDialog {
 
         try {
             ComponentBuilder builder = ComponentBuilderFactory.getBuilder(ComponentBuilderFactory.GENERIC_BUILDER);
-            for (JComponent component : builder.build(null, thing, callback)) {
+            for (JComponent component : builder.build(null, thing, callback, 0)) {
                 items.add(component);
             }
         } catch (Exception e) {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/BitPointComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/BitPointComponentBuilder.java
@@ -4,13 +4,6 @@ import com.bitdecay.jump.geom.BitPoint;
 import com.bitdecay.jump.leveleditor.ui.PropModUICallback;
 
 import javax.swing.*;
-import javax.swing.event.CaretEvent;
-import javax.swing.event.CaretListener;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import java.awt.*;
-import java.awt.event.InputMethodEvent;
-import java.awt.event.InputMethodListener;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +11,7 @@ import java.util.List;
 public class BitPointComponentBuilder implements ComponentBuilder {
 
     @Override
-    public List<JComponent> build(Field field, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException {
+    public List<JComponent> build(Field field, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException {
 
         BitPoint bitPoint = (BitPoint) field.get(thing);
         JComponent xComponent = ComponentUtils.buildSlider((int) bitPoint.x, -200, 200, new Callable() {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/BooleanComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/BooleanComponentBuilder.java
@@ -13,7 +13,7 @@ public class BooleanComponentBuilder implements ComponentBuilder {
     private boolean lastState;
 
     @Override
-    public List<JComponent> build(Field field, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException {
+    public List<JComponent> build(Field field, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException {
         JCheckBox checkBox = new JCheckBox();
         checkBox.setSelected(field.getBoolean(thing));
         lastState = checkBox.isSelected();

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/ComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/ComponentBuilder.java
@@ -7,5 +7,5 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 public interface ComponentBuilder {
-    List<JComponent> build(Field field, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException;
+    List<JComponent> build(Field field, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException;
 }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/FloatComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/FloatComponentBuilder.java
@@ -1,19 +1,23 @@
 package com.bitdecay.jump.leveleditor.ui.component;
 
+import com.bitdecay.jump.annotation.ValueRange;
 import com.bitdecay.jump.leveleditor.ui.PropModUICallback;
 
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.Hashtable;
 import java.util.List;
 
 public class FloatComponentBuilder implements ComponentBuilder {
     @Override
-    public List<JComponent> build(Field field, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException {
-        return Arrays.asList(ComponentUtils.buildSlider((int) (field.getFloat(thing) * 100), 0, 100, new Callable() {
+    public List<JComponent> build(Field field, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException {
+        int min = 0;
+        int max = 1000;
+        if (field.isAnnotationPresent(ValueRange.class)) {
+            min = field.getAnnotation(ValueRange.class).min();
+            max = field.getAnnotation(ValueRange.class).max();
+        }
+        return Arrays.asList(ComponentUtils.buildSlider((int) (field.getFloat(thing) * 100), min * 100, max * 100, new Callable() {
             @Override
             public void call(Object value) {
                 try {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/GenericComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/GenericComponentBuilder.java
@@ -1,15 +1,17 @@
 package com.bitdecay.jump.leveleditor.ui.component;
 
+import com.bitdecay.jump.annotation.CanLoadFromFile;
+import com.bitdecay.jump.annotation.CantInspect;
+import com.bitdecay.jump.level.FileUtils;
 import com.bitdecay.jump.leveleditor.ui.PropModUICallback;
 
 import javax.swing.*;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.util.*;
 import java.util.List;
 
 /**
@@ -17,27 +19,68 @@ import java.util.List;
  */
 public class GenericComponentBuilder implements ComponentBuilder {
     @Override
-    public List<JComponent> build(Field narrowingField, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException {
+    public List<JComponent> build(Field narrowingField, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException {
+        boolean canLoadFromFile = false;
+        final Object inspectedObject;
         if (narrowingField != null) {
-            thing = narrowingField.get(thing);
+            inspectedObject = narrowingField.get(thing);
+            if (narrowingField.isAnnotationPresent(CanLoadFromFile.class)) {
+                canLoadFromFile = true;
+            }
+        } else {
+            inspectedObject = thing;
         }
         JPanel fieldPanel = new JPanel();
         fieldPanel.setLayout(new BoxLayout(fieldPanel, BoxLayout.Y_AXIS));
         List<Field> fields = new ArrayList<>();
-        fields.addAll(Arrays.asList(thing.getClass().getSuperclass().getDeclaredFields()));
-        fields.addAll(Arrays.asList(thing.getClass().getDeclaredFields()));
-        fields.sort(new Comparator<Field>() {
-            @Override
-            public int compare(Field o1, Field o2) {
-                return o1.getName().compareTo(o2.getName());
-            }
-        });
+        fields.addAll(Arrays.asList(inspectedObject.getClass().getSuperclass().getDeclaredFields()));
+        fields.addAll(Arrays.asList(inspectedObject.getClass().getDeclaredFields()));
+
+        if (canLoadFromFile) {
+            JPanel filePanel = new JPanel();
+            filePanel.setLayout(new BoxLayout(filePanel, BoxLayout.X_AXIS));
+            JButton loadBtn = new JButton();
+            loadBtn.setText("Load from file");
+            filePanel.add(loadBtn);
+            loadBtn.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    Object loaded = FileUtils.loadFileAs(narrowingField.getType());
+                    if (loaded != null) {
+                        try {
+                            narrowingField.set(thing, loaded);
+                            fieldPanel.removeAll();
+                            build(narrowingField, thing, callback, depth).forEach(component -> fieldPanel.add(component));
+                            fieldPanel.revalidate();
+                            callback.propertyChanged("Loaded From file", thing);
+                        } catch (Exception e1) {
+                            e1.printStackTrace();
+                        }
+                    }
+                }
+            });
+
+            JButton saveBtn = new JButton();
+            saveBtn.setText("Save to file");
+            filePanel.add(saveBtn);
+            saveBtn.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    FileUtils.saveToFile(inspectedObject);
+                }
+            });
+
+            fieldPanel.add(filePanel);
+        }
+
         boolean first = true;
         for (Field field : fields) {
+            if (field.isAnnotationPresent(CantInspect.class)) {
+                continue;
+            }
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            System.out.println(field.getName());
             if (!first) {
                 fieldPanel.add(new JSeparator(JSeparator.CENTER));
             } else {
@@ -46,13 +89,20 @@ public class GenericComponentBuilder implements ComponentBuilder {
             try {
                 ComponentBuilder builder = ComponentBuilderFactory.getBuilder(field.getType().getName());
                 if (builder != null) {
-                    List<JComponent> component = builder.build(field, thing, callback);
-                    if (component != null) {
-                        JLabel label = new JLabel(field.getName());
-                        fieldPanel.add(label);
-                        for (JComponent jComponent : component) {
-                            fieldPanel.add(jComponent);
+                    List<JComponent> components = builder.build(field, inspectedObject, callback, depth + 1);
+                    if (components != null && components.size() > 0) {
+                        JPanel subFieldPanel = new JPanel();
+                        subFieldPanel.setLayout(new BorderLayout());
+                        Color borderColor = new Color(100, 100, 100);
+                        for (int i = 0; i < depth; i++) {
+                            borderColor = borderColor.brighter();
                         }
+                        subFieldPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createLineBorder(borderColor, 2), field.getName()));
+
+                        for (JComponent jComponent : components) {
+                            subFieldPanel.add(jComponent);
+                        }
+                        fieldPanel.add(subFieldPanel);
                         fieldPanel.add(Box.createVerticalStrut(5));
                     }
                 } else {
@@ -60,6 +110,7 @@ public class GenericComponentBuilder implements ComponentBuilder {
                 }
             } catch (Exception e) {
                 System.out.println("Unable to build component for " + field.getName() + " of type " + field.getType());
+                e.printStackTrace();
             }
         }
         return Arrays.asList(fieldPanel);

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/IntComponentBuilder.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/ui/component/IntComponentBuilder.java
@@ -1,10 +1,10 @@
 package com.bitdecay.jump.leveleditor.ui.component;
 
+import com.bitdecay.jump.annotation.ValueRange;
 import com.bitdecay.jump.leveleditor.ui.PropModUICallback;
+import jdk.internal.org.objectweb.asm.tree.analysis.Value;
 
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -12,8 +12,14 @@ import java.util.List;
 public class IntComponentBuilder implements ComponentBuilder {
 
     @Override
-    public List<JComponent> build(Field field, Object thing, PropModUICallback callback) throws IllegalArgumentException, IllegalAccessException {
-        return Arrays.asList(ComponentUtils.buildSlider(field.getInt(thing), 0, 1000, new Callable() {
+    public List<JComponent> build(Field field, Object thing, PropModUICallback callback, int depth) throws IllegalArgumentException, IllegalAccessException {
+        int min = 0;
+        int max = 1000;
+        if (field.isAnnotationPresent(ValueRange.class)) {
+            min = field.getAnnotation(ValueRange.class).min();
+            max = field.getAnnotation(ValueRange.class).max();
+        }
+        return Arrays.asList(ComponentUtils.buildSlider(field.getInt(thing), min, max, new Callable() {
             @Override
             public void call(Object value) {
                 try {


### PR DESCRIPTION
Fixes #117 

There are now the following annotations:

@CantInspect Which will cause the inspect tool to ignore these values
@ValueRange which can specify a minimum/maximum value that the inspect tool will use for the slider. (A user can still go outside of these ranges with the text field if they so choose)