### PR TITLE
Trying to run will no longer slow you down instantly if you've been l…

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/control/state/SidewaysControlState.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/control/state/SidewaysControlState.java
@@ -4,7 +4,6 @@ import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.Facing;
 import com.bitdecay.jump.control.ControlMap;
 import com.bitdecay.jump.control.PlayerAction;
-import com.bitdecay.jump.geom.BitPoint;
 
 /**
  * Created by Monday on 11/4/2015.
@@ -21,22 +20,26 @@ public abstract class SidewaysControlState implements JumperBodyControlState {
                     if (decel == 0) {
                         body.velocity.x = 0;
                     }
-                    body.velocity.x = accel == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
+                    body.velocity.x = accel == 0 ? -body.props.maxVoluntarySpeed : Math.max(-body.props.maxVoluntarySpeed, body.velocity.x
                             - (accel + decel) * delta);
+                } else if (body.velocity.x < -body.props.maxVoluntarySpeed) {
+                    body.velocity.x += (decel * delta);
                 } else {
-                    body.velocity.x = accel == 0 ? -body.props.maxSpeed.x : Math.max(-body.props.maxSpeed.x, body.velocity.x
+                    body.velocity.x = accel == 0 ? -body.props.maxVoluntarySpeed : Math.max(-body.props.maxVoluntarySpeed, body.velocity.x
                             - accel * delta);
                 }
             } else {
-                if (body.velocity.x > 0) {
-                    body.velocity.x = accel == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
-                            + accel * delta);
-                } else {
+                if (body.velocity.x < 0) {
                     if (decel == 0) {
                         body.velocity.x = 0;
                     }
-                    body.velocity.x = accel == 0 ? body.props.maxSpeed.x : Math.min(body.props.maxSpeed.x, body.velocity.x
+                    body.velocity.x = accel == 0 ? body.props.maxVoluntarySpeed : Math.min(body.props.maxVoluntarySpeed, body.velocity.x
                             + (accel + decel) * delta);
+                } else if (body.velocity.x > body.props.maxVoluntarySpeed) {
+                    body.velocity.x -= (decel * delta);
+                } else {
+                    body.velocity.x = accel == 0 ? body.props.maxVoluntarySpeed : Math.min(body.props.maxVoluntarySpeed, body.velocity.x
+                            + accel * delta);
                 }
             }
         } else {

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
@@ -36,9 +36,9 @@ public class BitBodyProperties {
     public int airDeceleration = 0;
 
     /**
-     * The max speed of the body
+     * The max 'running' speed of the body
      */
-    public BitPoint maxSpeed = new BitPoint(300, 0);
+    public int maxVoluntarySpeed = 300;
 
     /**
      * A flag for whether or not gravity should affect this body


### PR DESCRIPTION
…aunched past your normal top speed

Fixes #102

Previously, if you were pushed past your top speed, trying to run *with* your momentum would result in you instantly being capped at your otherwise normal top speed. It feels bad so I changed it. Now a body will decelerate per it's configuration until you reach your top speed.