### PR TITLE
add listener changes, user objects and example code

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/BitBody.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/BitBody.java
@@ -20,6 +20,12 @@ import java.util.Set;
 public class BitBody {
 
     /**
+     * A generic object we can attach to a body. Useful for accessing game objects
+     * during collisions.
+     */
+    public Object userObject;
+
+    /**
      * Basic properties defining the configurable behavior of this body
      */
     public BitBodyProperties props = new BitBodyProperties();
@@ -117,6 +123,14 @@ public class BitBody {
         } catch (IllegalAccessException iae){
             throw new BitBodySerializeException("The property: " + prop + " is not marked as public", iae);
         }
+    }
+
+    public void addContactListener(ContactListener listener) {
+        contactListeners.add(listener);
+    }
+
+    public void removeContactListener(ContactListener listener) {
+        contactListeners.remove(listener);
     }
 
     public List<ContactListener> getContactListeners() {

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
@@ -11,6 +11,7 @@ import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.BodyType;
 import com.bitdecay.jump.JumperBody;
 import com.bitdecay.jump.collision.BitWorld;
+import com.bitdecay.jump.collision.ContactListener;
 import com.bitdecay.jump.gdx.level.EditorIdentifierObject;
 import com.bitdecay.jump.gdx.level.RenderableLevelObject;
 import com.bitdecay.jump.geom.BitRectangle;
@@ -148,6 +149,27 @@ public class ExampleEditorLevel implements EditorHook {
             playerBody.aabb = new BitRectangle(level.debugSpawn.rect.xy.x,level.debugSpawn.rect.xy.y,16,32);
             playerBody.renderStateWatcher = new JumperRenderStateWatcher();
             playerBody.controller = new PlayerInputController(GDXControls.defaultMapping);
+
+            playerBody.addContactListener(new ContactListener() {
+                @Override
+                public void contactStarted(BitBody other) {
+                    if (other.userObject instanceof SecretObject) {
+                        playerBody.props.gravityModifier = -1;
+                    }
+                }
+
+                @Override
+                public void contactEnded(BitBody other) {
+                    if (other.userObject instanceof SecretObject) {
+                        playerBody.props.gravityModifier = 1;
+                    }
+                }
+
+                @Override
+                public void crushed() {
+
+                }
+            });
 
             world.addBody(playerBody);
         }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/SecretObject.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/SecretObject.java
@@ -18,6 +18,7 @@ public class SecretObject extends GameObject {
     @Override
     public BitBody build(LevelObject template) {
         body = template.buildBody();
+        body.userObject = this;
         this.texture = new TextureRegion(new Texture(Gdx.files.internal(LevelEditor.EDITOR_ASSETS_FOLDER + "/question.png")));
         return body;
     }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/SecretThing.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/SecretThing.java
@@ -27,6 +27,7 @@ public class SecretThing extends RenderableLevelObject {
     @Override
     public BitBody buildBody() {
         BitBody body = new BitBody();
+        body.props.collides = false;
         body.bodyType = BodyType.STATIC;
         body.aabb = new BitRectangle(rect);
         return body;


### PR DESCRIPTION
Fixes #129

Listeners can now be registered.

Can attach generic object to BitBody so we can get game data during collision events.