### PR TITLE
Max of 1 second worth of simulation

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
@@ -104,6 +104,9 @@ public class BitWorld {
 		if (delta <= 0) {
 			nonStep();
 			return false;
+		} else if (delta > 1) {
+			// if we lose focus or something, never calculate more than 1 second worth of simulation
+			delta = 1;
 		}
 
 		boolean stepped = false;


### PR DESCRIPTION
Fixes #133 

Hard cap of 120 (1 second worth) simulation steps for a given call to update.