### PR TITLE
Texture packing

### DIFF
--- a/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTextureAtlas.java
+++ b/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTextureAtlas.java
@@ -1,0 +1,31 @@
+package com.bitdecay.jump.gdx.integration;
+
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.utils.Array;
+
+/**
+ * Created by Monday on 11/12/2015.
+ */
+public class BitTextureAtlas extends TextureAtlas {
+    public BitTextureAtlas(TextureAtlasData data) {
+        super(data);
+    }
+
+    public Array<AtlasRegion> findRegions(String name) {
+        Array<AtlasRegion> regions = super.findRegions(name);
+        if (regions.size > 0) {
+            return regions;
+        } else {
+            int i = 1;
+            while (true) {
+                Array<AtlasRegion> numberedRegions = super.findRegions(name + "/" + i++);
+                if (numberedRegions.size == 0) {
+                    break;
+                } else {
+                    regions.addAll(numberedRegions);
+                }
+            }
+            return regions;
+        }
+    }
+}

--- a/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTextureAtlasLoader.java
+++ b/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTextureAtlasLoader.java
@@ -1,0 +1,69 @@
+package com.bitdecay.jump.gdx.integration;
+
+import com.badlogic.gdx.assets.AssetDescriptor;
+import com.badlogic.gdx.assets.AssetLoaderParameters;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.assets.loaders.SynchronousAssetLoader;
+import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas.TextureAtlasData;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas.TextureAtlasData.Page;
+import com.badlogic.gdx.utils.Array;
+
+import java.util.Iterator;
+
+public class BitTextureAtlasLoader extends SynchronousAssetLoader<BitTextureAtlas, BitTextureAtlasLoader.BitTextureAtlasParameter> {
+    TextureAtlasData data;
+
+    public BitTextureAtlasLoader(FileHandleResolver resolver) {
+        super(resolver);
+    }
+
+    public BitTextureAtlas load(AssetManager assetManager, String fileName, FileHandle file, BitTextureAtlasLoader.BitTextureAtlasParameter parameter) {
+        Page page;
+        Texture texture;
+        for(Iterator var5 = this.data.getPages().iterator(); var5.hasNext(); page.texture = texture) {
+            page = (Page)var5.next();
+            texture = (Texture)assetManager.get(page.textureFile.path().replaceAll("\\\\", "/"), Texture.class);
+        }
+
+        return new BitTextureAtlas(this.data);
+    }
+
+    public Array<AssetDescriptor> getDependencies(String fileName, FileHandle atlasFile, BitTextureAtlasLoader.BitTextureAtlasParameter parameter) {
+        FileHandle imgDir = atlasFile.parent();
+        if(parameter != null) {
+            this.data = new TextureAtlasData(atlasFile, imgDir, parameter.flip);
+        } else {
+            this.data = new TextureAtlasData(atlasFile, imgDir, false);
+        }
+
+        Array dependencies = new Array();
+        Iterator var6 = this.data.getPages().iterator();
+
+        while(var6.hasNext()) {
+            Page page = (Page)var6.next();
+            TextureParameter params = new TextureParameter();
+            params.format = page.format;
+            params.genMipMaps = page.useMipMaps;
+            params.minFilter = page.minFilter;
+            params.magFilter = page.magFilter;
+            dependencies.add(new AssetDescriptor(page.textureFile, Texture.class, params));
+        }
+
+        return dependencies;
+    }
+
+    public static class BitTextureAtlasParameter extends AssetLoaderParameters<BitTextureAtlas> {
+        public boolean flip = false;
+
+        public BitTextureAtlasParameter() {
+        }
+
+        public BitTextureAtlasParameter(boolean flip) {
+            this.flip = flip;
+        }
+    }
+}

--- a/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTexturePacker.java
+++ b/jump-gdx/src/main/java/com/bitdecay/jump/gdx/integration/BitTexturePacker.java
@@ -1,0 +1,70 @@
+package com.bitdecay.jump.gdx.integration;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.tools.texturepacker.TexturePacker;
+
+import java.io.File;
+import java.io.FileFilter;
+
+public class BitTexturePacker {
+
+    FileFilter directoryFilter = new FileFilter() {
+        @Override
+        public boolean accept(File pathname) {
+            return pathname.isDirectory();
+        }
+    };
+    private File inputDir;
+    private File outputDir;
+
+    public BitTexturePacker(File inputDir, File outputDir) {
+        this.inputDir = inputDir;
+        this.outputDir = outputDir;
+    }
+
+    public void pack() {
+        TexturePacker.Settings settings = new TexturePacker.Settings();
+        settings.maxWidth *= 4;
+        settings.maxHeight *= 4;
+        settings.combineSubdirectories = true;
+        settings.duplicatePadding = true;
+        settings.fast = true;
+        settings.filterMin = Texture.TextureFilter.Nearest;
+        settings.filterMag = Texture.TextureFilter.Nearest;
+
+        System.out.println("Start packing textures");
+        int count = 0;
+        long startTime = System.currentTimeMillis();
+        for (File subDir : inputDir.listFiles(directoryFilter)) {
+            count++;
+            System.out.println("\n****Packing atlas '" + subDir.getName() + "'");
+            TexturePacker.process(settings, subDir.getAbsolutePath(), outputDir.getAbsolutePath(), subDir.getName());
+        }
+        long duration = System.currentTimeMillis() - startTime;
+        System.out.println("Finished packing textures");
+        System.out.println("Atlases Packed: " + count);
+        System.out.println(String.format("Total time: %.2f seconds", duration / 1000f));
+    }
+
+    public static void main(String[] args) {
+        if (args.length != 2) {
+            System.err.println("Usage: <topLevelInputDirectory> <topLevelOutputDirectory>");
+            System.exit(-1);
+        }
+
+        File inputDir = new File(args[0]);
+        if (!inputDir.isDirectory()) {
+            System.err.println(args[0] + " must be a directory");
+        }
+
+        File outputDir = new File(args[1]);
+        if (!outputDir.isDirectory()) {
+            System.err.println(args[1] + " must be a directory");
+        }
+
+        BitTexturePacker packer = new BitTexturePacker(inputDir, outputDir);
+        packer.pack();
+    }
+}

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/ExampleEditorLevel.java
@@ -21,9 +21,11 @@ import com.bitdecay.jump.level.builder.TileObject;
 import com.bitdecay.jump.leveleditor.EditorHook;
 import com.bitdecay.jump.leveleditor.example.game.GameObject;
 import com.bitdecay.jump.leveleditor.example.game.SecretObject;
+import com.bitdecay.jump.leveleditor.example.game.ShellObject;
 import com.bitdecay.jump.leveleditor.example.level.SecretThing;
 import com.bitdecay.jump.gdx.input.GDXControls;
 import com.bitdecay.jump.control.PlayerInputController;
+import com.bitdecay.jump.leveleditor.example.level.ShellLevelObject;
 import com.bitdecay.jump.leveleditor.render.LevelEditor;
 import com.bitdecay.jump.render.JumperRenderStateWatcher;
 
@@ -193,10 +195,10 @@ public class ExampleEditorLevel implements EditorHook {
     @Override
     public List<RenderableLevelObject> getCustomObjects() {
         builderMap.put(SecretThing.class, SecretObject.class);
+        builderMap.put(ShellLevelObject.class, ShellObject.class);
         List<RenderableLevelObject> exampleItems = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            exampleItems.add(new SecretThing());
-        }
+        exampleItems.add(new SecretThing());
+        exampleItems.add(new ShellLevelObject());
         return exampleItems;
     }
 }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/ShellController.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/ShellController.java
@@ -1,0 +1,43 @@
+package com.bitdecay.jump.leveleditor.example.game;
+
+import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.control.BitBodyController;
+
+/**
+ * Created by Monday on 11/12/2015.
+ */
+public class ShellController implements BitBodyController {
+    boolean moving = true;
+    boolean left = false;
+
+    int speed;
+
+    public ShellController(int speed) {
+        this.speed = speed;
+    }
+
+    @Override
+    public void update(float delta, BitBody body) {
+        if (moving) {
+            if (left) {
+                if (body.lastResolution.x > 0) {
+                    left = false;
+                    return;
+                } else {
+                    body.velocity.x = -speed;
+                }
+            } else {
+                if (body.lastResolution.x < 0) {
+                    left = true;
+                } else {
+                    body.velocity.x = speed;
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getStatus() {
+        return "Shell";
+    }
+}

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/ShellObject.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/game/ShellObject.java
@@ -1,0 +1,28 @@
+package com.bitdecay.jump.leveleditor.example.game;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.level.builder.LevelObject;
+
+/**
+ * Created by Monday on 11/12/2015.
+ */
+public class ShellObject extends GameObject {
+
+    @Override
+    public BitBody build(LevelObject template) {
+        BitBody body = template.buildBody();
+        body.controller = new ShellController(250);
+        return body;
+    }
+
+    @Override
+    public void update(float delta) {
+
+    }
+
+    @Override
+    public void render(SpriteBatch batch) {
+
+    }
+}

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/ShellLevelObject.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/ShellLevelObject.java
@@ -1,0 +1,43 @@
+package com.bitdecay.jump.leveleditor.example.level;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.BodyType;
+import com.bitdecay.jump.gdx.level.RenderableLevelObject;
+import com.bitdecay.jump.geom.BitRectangle;
+import com.bitdecay.jump.leveleditor.render.LevelEditor;
+
+/**
+ * Created by Monday on 11/13/2015.
+ */
+public class ShellLevelObject extends RenderableLevelObject {
+    TextureRegion texture;
+
+    public ShellLevelObject() {
+        rect = new BitRectangle(0, 0, 16 ,16);
+        this.texture = new TextureRegion(new Texture(Gdx.files.internal(LevelEditor.EDITOR_ASSETS_FOLDER + "/question.png")));
+        texture.setRegionHeight(16);
+        texture.setRegionWidth(16);
+    }
+
+    @Override
+    public BitBody buildBody() {
+        BitBody body = new BitBody();
+        body.aabb = new BitRectangle(rect);
+        body.bodyType = BodyType.DYNAMIC;
+        body.props.gravitational = true;
+        return body;
+    }
+
+    @Override
+    public String name() {
+        return "Shell";
+    }
+
+    @Override
+    public TextureRegion texture() {
+        return texture;
+    }
+}


### PR DESCRIPTION
This was pulled from a major tangent I got lost on when looking through @Kenoshen 's animagic code.

The idea is that now we can just place assets in a resource folder and have everything bundled up and easily identifiable by the path name. Ex:

```
rootDir
|- Character
|    |- Run
|    |    |- 1.png
|    |    |- 2.png
|    |- Jump
|         |- 1.png
|         |- 2.png
|- Items
     |- HealthPotion
          | - 1.png
```

The above would be the file structure, and now we can get our atlas and just call something like the following:

`atlas.FindRegions("Character/Run")` and get all frames of the run folder
`atlas.FindRegions("Character/Jump")` and get all frames of the jump folder
`atlas.FindRegions("Items/HealthPotion")` and get all frames of the HealthPotion folder

This currently hinges on the files being named numerically and being 1-based. But it should be convenient since we previously had to code a solution to this in the game itself.