### PR TITLE
Prep for dynamic collisions. Contact listener improvements

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/BitBody.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/BitBody.java
@@ -93,6 +93,12 @@ public class BitBody {
 	 */
 	public BitPoint lastResolution = new BitPoint(0, 0);
 
+    /**
+     * Flag that tells the engine not to let this body undergo any more
+     * collision resolution during the current world step.
+     */
+    public boolean resolutionLocked;
+
 	/**
 	 * Only active bodies are updated in the world
 	 */

--- a/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/BitWorld.java
@@ -458,7 +458,8 @@ public class BitWorld {
 			return;
 		} else if (body.resolutionLocked) {
 			return;
-		} else {
+		} else if (BodyType.DYNAMIC.equals(body.bodyType) ^ BodyType.DYNAMIC.equals(against.bodyType)) {
+			// all we have to do is take out the xor if and dynamic bodies will collide. There are still bugs, however
 			if (!pendingResolutions.containsKey(body)) {
 				pendingResolutions.put(body, new SATStrategy(body));
 			}

--- a/jump-core/src/main/java/com/bitdecay/jump/collision/SATCollision.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/SATCollision.java
@@ -50,7 +50,10 @@ public class SATCollision {
         manifoldCandidates.sort((o1, o2) -> Float.compare(Math.abs(o1.distance), Math.abs(o2.distance)));
         // this line is just taking where the body tried to move and the partially resolved position into account to
         // figure out the relative momentum.
-        BitPoint relativeMovement = body.currentAttempt.plus(cumulativeResolution).minus(otherBody.currentAttempt);
+        BitPoint bodyAttempt = body.resolutionLocked ? new BitPoint(0, 0) : body.currentAttempt;
+        BitPoint otherBodyAttempt = otherBody.resolutionLocked ? new BitPoint(0, 0) : otherBody.currentAttempt;
+        BitPoint relativeMovement = bodyAttempt.plus(cumulativeResolution).minus(otherBodyAttempt);
+
         float dotProd;
         for (Manifold manifold : manifoldCandidates) {
             dotProd = relativeMovement.dot(manifold.axis);

--- a/jump-core/src/main/java/com/bitdecay/jump/collision/SATStrategyComparator.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/SATStrategyComparator.java
@@ -1,0 +1,22 @@
+package com.bitdecay.jump.collision;
+
+/**
+ * Created by Monday on 11/18/2015.
+ */
+public class SATStrategyComparator implements java.util.Comparator {
+    @Override
+    public int compare(Object o1, Object o2) {
+        SATStrategy first = (SATStrategy) o1;
+        SATStrategy second = (SATStrategy) o2;
+        int firstWeight = 0;
+        int secondWeight = 0;
+
+        for (BitCollision col : first.collisions) {
+            firstWeight += col.against.bodyType.order;
+        }
+        for (BitCollision col : second.collisions) {
+            secondWeight += col.against.bodyType.order;
+        }
+        return -1 * Integer.compare(firstWeight, secondWeight);
+    }
+}

--- a/jump-core/src/main/java/com/bitdecay/jump/collision/SATUtilities.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/collision/SATUtilities.java
@@ -38,7 +38,7 @@ public class SATUtilities {
                 res.addCandidate(new Manifold(axis, overlap));
             } else {
                 // if any axis has no overlap, then the shapes do not intersect
-                return new SATCollision();
+                return null;
             }
         }
         return res;

--- a/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/properties/BitBodyProperties.java
@@ -12,6 +12,11 @@ public class BitBodyProperties {
     public boolean collides = true;
 
     /**
+     * Flag dictating if conflicting resolutions will deactive the body
+     */
+    public boolean crushable = true;
+
+    /**
      * The acceleration of the body while on the ground
      */
     @ValueRange(min = 0, max = 5000)

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/ShellLevelObject.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/example/level/ShellLevelObject.java
@@ -28,6 +28,7 @@ public class ShellLevelObject extends RenderableLevelObject {
         body.aabb = new BitRectangle(rect);
         body.bodyType = BodyType.DYNAMIC;
         body.props.gravitational = true;
+        body.props.crushable = false;
         return body;
     }
 


### PR DESCRIPTION
This has a whole slew of changes for preparation of dynamic vs dynamic body collisions. They are currently disabled since there are still bugs -- but everything else should work correctly.

The other major piece here is how contact listener events are fired. It has been cleaned up so that events all fire at the end of the world step instead of in the middle -- as that can lead to weird behaviors.

Fixes #143