### PR TITLE
Quick and major refactor. Triggers are now their own objects instead …

### DIFF
--- a/jump-core/src/main/java/com/bitdecay/jump/geom/BitRectangle.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/geom/BitRectangle.java
@@ -33,6 +33,10 @@ public class BitRectangle implements Projectable {
 		this(startPoint.x, startPoint.y, endPoint.x - startPoint.x, endPoint.y - startPoint.y);
 	}
 
+	public BitRectangle(BitPoint startPoint, BitPoint endPoint) {
+		this(startPoint.x, startPoint.y, endPoint.x - startPoint.x, endPoint.y - startPoint.y);
+	}
+
 	public void set(BitRectangle other) {
 		this.xy.set(other.xy);
 		this.width = other.width;
@@ -64,7 +68,11 @@ public class BitRectangle implements Projectable {
 		return contains(point.x, point.y);
 	}
 
-	public boolean contains(int x, int y) {
+	public boolean contains(BitPoint point) {
+		return contains(point.x, point.y);
+	}
+
+	public boolean contains(float x, float y) {
 		return x >= xy.x && x <= xy.x + width && y >= xy.y && y <= xy.y + height;
 	}
 

--- a/jump-core/src/main/java/com/bitdecay/jump/level/DebugSpawnObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/DebugSpawnObject.java
@@ -52,4 +52,9 @@ public class DebugSpawnObject extends LevelObject {
     public String name() {
         return "Debug Spawn Point";
     }
+
+    @Override
+    public boolean selects(BitPointInt point) {
+        return rect.xy.minus(point).len() < DebugSpawnObject.OUTER_DIAMETER;
+    }
 }

--- a/jump-core/src/main/java/com/bitdecay/jump/level/Level.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/Level.java
@@ -9,6 +9,7 @@ public class Level {
 	public int tileSize = 16;
 	public TileObject[][] gridObjects;
 	public List<LevelObject> otherObjects;
+	public List<TriggerObject> triggers;
 	/**
 	 * This offset is to compensate from how far from the origin the 2d array
 	 * sits. This is needed due to the array being 'shrink wrapped' to the grid
@@ -28,12 +29,14 @@ public class Level {
 		this.tileSize = unitSize;
 		gridObjects = new TileObject[10][10];
 		otherObjects = new ArrayList<>();
+		triggers = new ArrayList<>();
 	}
 
 	public Level(Level level) {
 		tileSize = level.tileSize;
 		gridObjects = level.gridObjects;
 		otherObjects = level.otherObjects;
+		triggers = level.triggers;
 		gridOffset = level.gridOffset;
 		debugSpawn = level.debugSpawn;
 		theme = level.theme;

--- a/jump-core/src/main/java/com/bitdecay/jump/level/LevelObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/LevelObject.java
@@ -2,6 +2,7 @@ package com.bitdecay.jump.level;
 
 import com.bitdecay.jump.BitBody;
 import com.bitdecay.jump.annotation.CantInspect;
+import com.bitdecay.jump.geom.BitPointInt;
 import com.bitdecay.jump.geom.BitRectangle;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -16,9 +17,6 @@ public abstract class LevelObject {
 	@CantInspect
 	public final String uuid = UUID.randomUUID().toString();
 
-	@CantInspect
-	public List<String> objectsTriggeredByThis = new ArrayList<>();
-
 	public LevelObject() {
 		// Here for JSON
 	}
@@ -31,4 +29,12 @@ public abstract class LevelObject {
 	public abstract BitBody buildBody();
 
 	public abstract String name();
+
+	public boolean selects(BitPointInt point) {
+		return rect.contains(point);
+	}
+
+	public boolean selects(BitRectangle selectionRect) {
+		return selectionRect.contains(rect);
+	}
 }

--- a/jump-core/src/main/java/com/bitdecay/jump/level/TriggerObject.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/TriggerObject.java
@@ -1,0 +1,44 @@
+package com.bitdecay.jump.level;
+
+import com.bitdecay.jump.BitBody;
+import com.bitdecay.jump.geom.BitPointInt;
+import com.bitdecay.jump.geom.BitRectangle;
+
+/**
+ * Created by Monday on 11/23/2015.
+ */
+public class TriggerObject extends LevelObject {
+    public LevelObject triggerer;
+    public LevelObject triggeree;
+
+    public TriggerObject() {
+        // Here for JSON
+    }
+
+    public TriggerObject(LevelObject triggerer, LevelObject triggeree) {
+        super(new BitRectangle(triggerer.rect.center().plus(triggeree.rect.center()).dividedBy(2),
+                triggerer.rect.center().plus(triggeree.rect.center()).dividedBy(2)));
+        this.triggerer = triggerer;
+        this.triggeree = triggeree;
+    }
+
+    @Override
+    public BitBody buildBody() {
+        return null;
+    }
+
+    @Override
+    public String name() {
+        return "Trigger";
+    }
+
+    @Override
+    public boolean selects(BitPointInt point) {
+        return rect.xy.minus(point).len() < 10;
+    }
+
+    @Override
+    public boolean selects(BitRectangle selectionRect) {
+        return selectionRect.contains(rect.xy);
+    }
+}

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/AddRemoveAction.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/AddRemoveAction.java
@@ -23,12 +23,12 @@ public class AddRemoveAction implements BuilderAction {
     @Override
     public void perform(LevelBuilder builder) {
         removeObjects.addAll(builder.addObjects(newObjects));
-        builder.removeObjects(removeObjects);
+        newObjects.addAll(builder.removeObjects(removeObjects));
     }
 
     @Override
     public void undo(LevelBuilder builder) {
-        builder.removeObjects(newObjects);
+        removeObjects.addAll(builder.removeObjects(newObjects));
         newObjects.addAll(builder.addObjects(removeObjects));
     }
 }

--- a/jump-core/src/main/java/com/bitdecay/jump/level/builder/TriggerAction.java
+++ b/jump-core/src/main/java/com/bitdecay/jump/level/builder/TriggerAction.java
@@ -1,37 +1,25 @@
 package com.bitdecay.jump.level.builder;
 
-import com.bitdecay.jump.level.LevelObject;
+import com.bitdecay.jump.level.TriggerObject;
 
 /**
  * Created by Monday on 11/22/2015.
  */
 public class TriggerAction implements BuilderAction {
 
-    private LevelObject triggerer;
-    private LevelObject triggeree;
-    private boolean create;
+    private TriggerObject trigger;
 
-    public TriggerAction(LevelObject triggerer, LevelObject triggeree, boolean create) {
-        this.triggerer = triggerer;
-        this.triggeree = triggeree;
-        this.create = create;
+    public TriggerAction(TriggerObject trigger) {
+        this.trigger = trigger;
     }
 
     @Override
     public void perform(LevelBuilder builder) {
-        if (create) {
-            triggerer.objectsTriggeredByThis.add(triggeree.uuid);
-        } else {
-            triggerer.objectsTriggeredByThis.remove(triggeree.uuid);
-        }
+        builder.triggers.put(trigger.uuid, trigger);
     }
 
     @Override
     public void undo(LevelBuilder builder) {
-        if (create) {
-            triggerer.objectsTriggeredByThis.remove(triggeree.uuid);
-        } else {
-            triggerer.objectsTriggeredByThis.add(triggeree.uuid);
-        }
+        builder.triggers.remove(trigger.uuid);
     }
 }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LevelEditor.java
@@ -16,16 +16,13 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.math.Vector3;
 import com.bitdecay.jump.collision.BitWorld;
+import com.bitdecay.jump.gdx.level.BetterLevelObject;
 import com.bitdecay.jump.gdx.level.RenderableLevelObject;
 import com.bitdecay.jump.geom.BitPoint;
 import com.bitdecay.jump.geom.BitPointInt;
 import com.bitdecay.jump.geom.GeomUtils;
-import com.bitdecay.jump.level.Level;
-import com.bitdecay.jump.level.LevelUtilities;
+import com.bitdecay.jump.level.*;
 import com.bitdecay.jump.level.builder.LevelBuilder;
-import com.bitdecay.jump.level.LevelObject;
-import com.bitdecay.jump.level.DebugSpawnObject;
-import com.bitdecay.jump.level.UserSizedLevelObject;
 import com.bitdecay.jump.leveleditor.EditorHook;
 import com.bitdecay.jump.leveleditor.render.mouse.*;
 import com.bitdecay.jump.leveleditor.tools.BitColors;
@@ -224,7 +221,13 @@ public class LevelEditor extends InputAdapter implements Screen, OptionsUICallba
         shaper.begin(ShapeType.Line);
         shaper.setColor(BitColors.SELECTION);
         for (LevelObject obj : curLevelBuilder.selection) {
-            shaper.rect(obj.rect.xy.x, obj.rect.xy.y, obj.rect.width, obj.rect.height);
+            if (obj instanceof TriggerObject) {
+                shaper.circle(obj.rect.center().x, obj.rect.center().y, 10);
+            } else if (obj instanceof DebugSpawnObject) {
+                shaper.circle(obj.rect.xy.x, obj.rect.xy.y, DebugSpawnObject.OUTER_DIAMETER + DebugSpawnObject.INNER_DIAMETER);
+            } else {
+                shaper.rect(obj.rect.xy.x, obj.rect.xy.y, obj.rect.width, obj.rect.height);
+            }
         }
         if (curLevelBuilder.debugSpawn != null) {
             shaper.setColor(BitColors.SPAWN_OUTER);

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LibGDXLevelRenderer.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/LibGDXLevelRenderer.java
@@ -12,7 +12,6 @@ import com.bitdecay.jump.level.LevelObject;
 import com.bitdecay.jump.level.builder.LevelBuilder;
 import com.bitdecay.jump.leveleditor.tools.BitColors;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,22 +38,22 @@ public class LibGDXLevelRenderer {
             if (object instanceof RenderableLevelObject) {
                 batch.draw(((RenderableLevelObject) object).texture(), object.rect.xy.x, object.rect.xy.y, object.rect.width, object.rect.height);
             }
-            if (RenderLayer.TRIGGERS.enabled) {
-                renderer.setColor(BitColors.SELECTABLE);
-                LevelObject other;
-                for (String uuid : object.objectsTriggeredByThis) {
-                    other = builder.otherObjects.get(uuid);
-
-                    BitPoint middleOfLine = new BitPoint((object.rect.center().x + other.rect.center().x)/2,(object.rect.center().y + other.rect.center().y)/2);
-                    float angle = GeomUtils.angle(object.rect.center(), other.rect.center());
-                    renderer.polyline(GeomUtils.pointsToFloats(GeomUtils.translatePoints(GeomUtils.rotatePoints(arrow, angle), middleOfLine)));
-                    renderer.line(object.rect.center().x, object.rect.center().y, other.rect.center().x, other.rect.center().y);
-                }
-            }
             renderer.setColor(BitColors.INACTIVE_OBJECT);
             renderer.rect(object.rect.xy.x, object.rect.xy.y, object.rect.width, object.rect.height);
             LevelEditor.addStringForRender(object.name(), new BitPoint(object.rect.xy), RenderLayer.LEVEL_OBJECTS);
         });
+        if (RenderLayer.TRIGGERS.enabled) {
+            builder.triggers.values().forEach(trigger -> {
+                renderer.setColor(BitColors.SELECTABLE);
+                LevelObject actor = builder.otherObjects.get(trigger.triggerer.uuid);
+                LevelObject victim = builder.otherObjects.get(trigger.triggeree.uuid);
+
+                BitPoint middleOfLine = new BitPoint((actor.rect.center().x + victim.rect.center().x) / 2, (actor.rect.center().y + victim.rect.center().y) / 2);
+                float angle = GeomUtils.angle(actor.rect.center(), victim.rect.center());
+                renderer.polyline(GeomUtils.pointsToFloats(GeomUtils.translatePoints(GeomUtils.rotatePoints(arrow, angle), middleOfLine)));
+                renderer.line(actor.rect.center().x, actor.rect.center().y, victim.rect.center().x, victim.rect.center().y);
+            });
+        }
         batch.end();
         renderer.end();
     }

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/SpawnMouseMode.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/SpawnMouseMode.java
@@ -3,6 +3,7 @@ package com.bitdecay.jump.leveleditor.render.mouse;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.bitdecay.jump.geom.BitPointInt;
+import com.bitdecay.jump.level.DebugSpawnObject;
 import com.bitdecay.jump.level.builder.LevelBuilder;
 import com.bitdecay.jump.leveleditor.tools.BitColors;
 
@@ -14,7 +15,7 @@ public class SpawnMouseMode extends BaseMouseMode {
 
     @Override
     protected void mouseUpLogic(BitPointInt point, MouseButton button) {
-         builder.setDebugSpawn(point);
+         builder.setDebugSpawn(new DebugSpawnObject(point));
     }
 
     @Override

--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/TriggerMouseMode.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/render/mouse/TriggerMouseMode.java
@@ -3,6 +3,7 @@ package com.bitdecay.jump.leveleditor.render.mouse;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.bitdecay.jump.geom.BitPointInt;
+import com.bitdecay.jump.level.TriggerObject;
 import com.bitdecay.jump.level.builder.LevelBuilder;
 import com.bitdecay.jump.level.LevelObject;
 import com.bitdecay.jump.leveleditor.tools.BitColors;
@@ -26,9 +27,9 @@ public class TriggerMouseMode extends BaseMouseMode {
                 if (triggerer == null) {
                     triggerer = builder.selection.get(0);
                 } else {
-                    // create our trigger connection;
+                    // create our trigger
                     triggeree = builder.selection.get(0);
-                    builder.addTrigger(triggerer, triggeree);
+                    builder.createObject(new TriggerObject(triggerer, triggeree));
                     triggerer = null;
                     triggeree = null;
                 }


### PR DESCRIPTION
…of references floating around on other objects

Fixes #151 

Triggers are now their own level objects (specialty object with no body). Now a game can load all objects, then go back and tie things together by looking at the trigger objects on the level object.

I'll need to do some testing to see if the UUID's I chose for this will actually work, but I think it will be a lot easier to use now (in theory)