### PR TITLE
Maven install with source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ Also to note.  If your .iml files get deleted and you are now having build error
 - On the popup, say that you want to import it from existing sources and select the Maven option
 
 You should now have your project all put back together.  If it STILL didn't work, you might try starting over with a fresh workspace, importing the project from GitHub, and then copying over the file changes you made into the new workspace, and then delete the old workspace.
+
+### Maven Install
+```mvn clean source:jar install```

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,20 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
I was trying to debug the issue in jump from the last PR and it is kind of a pain to do that from a separate project when the separate project doesn't know where the source code lives.  The added plugin will include the source code when you run ```mvn clean source:jar install```.  I also just added that command to the README so that it is documented.