### PR TITLE
proposed fix for dealing with inter-jar resource management

### DIFF
--- a/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/utils/LevelUtilities.java
+++ b/jump-leveleditor/src/main/java/com/bitdecay/jump/leveleditor/utils/LevelUtilities.java
@@ -17,9 +17,12 @@ public class LevelUtilities {
 	}
 
 	public static Level loadLevel(File file) {
-
-		return null;
+		return FileUtils.loadFileAs(Level.class, file);
 	}
+
+	public static Level loadLevelFromJson(String json){
+        return FileUtils.loadFileAs(Level.class, json);
+    }
 
 	public static Level saveLevel(ILevelBuilder builder, boolean canCancel) {
 		if(canCancel) {


### PR DESCRIPTION
Ok, so here is why I did this... I'm trying to make it so that when we reference resources, that we are getting the resources from **within** the jar instead of having a separate folder outside of the jar with all of our resources.  When you are **inside** of the Gdx context (ie. after you have called new MyGame(...)) you get access to inter-jar resources by using Gdx.files.classpath(filePath).  However, when you are OUTSIDE of Gdx context you have to use this funky ClassLoader.getSystemResourceAsStream(filePath).

So, in this part of jump, there is no access to Gdx since there is no dependency (which there shouldn't be).  However, the method of accessing resources within jump is using just normal java File IO instead of the ClassLoader.getResource way.  That means that from jump, you can only ever load level files that are external to the jar.  I didn't want to make any major code changes to actually deal with that issue (maybe check the file io and then fallback onto looking into the jar, etc).  So instead, I just added another pass-through method to the FileUtils class from the level loader.  I could have just as easily put that FileUtils.loadAs method call into my game.  But I figured the **right** way is to add that method to the LevelUtils class since that is what we use to load levels.

Btw... you have FileUtilities **and** FileUtils in jump, kinda confusing.